### PR TITLE
Fix code scanning alert no. 2: Disabled Spring CSRF protection

### DIFF
--- a/authorization-with-keycloak/src/main/java/com/evegal/SecurityConfig.java
+++ b/authorization-with-keycloak/src/main/java/com/evegal/SecurityConfig.java
@@ -70,9 +70,7 @@ public class SecurityConfig {
 
         http.sessionManagement(sessions -> {
             sessions.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        }).csrf(csrf -> {
-            csrf.disable();
-        });
+        }).csrf();
 
         http.authorizeHttpRequests(requests -> {
             requests.anyRequest().authenticated();


### PR DESCRIPTION
Fixes [https://github.com/EvenGal/spring-projects/security/code-scanning/2](https://github.com/EvenGal/spring-projects/security/code-scanning/2)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This involves removing the `csrf.disable()` call and ensuring that CSRF protection is configured correctly. This change will help protect the application from CSRF attacks by ensuring that requests are verified to be intentionally sent by the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
